### PR TITLE
support enabling network integration via expo plugin

### DIFF
--- a/packages/react-native/android/src/main/java/com/bdreactnative/BdReactNativeModule.kt
+++ b/packages/react-native/android/src/main/java/com/bdreactnative/BdReactNativeModule.kt
@@ -14,24 +14,18 @@ import io.bitdrift.capture.Capture
 import io.bitdrift.capture.providers.session.SessionStrategy
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
-class BdReactNativeModule internal constructor(context: ReactApplicationContext):
+class BdReactNativeModule internal constructor(context: ReactApplicationContext) :
   BdReactNativeSpec(context) {
 
   override fun getName(): String {
     return NAME
   }
 
-  // Example method
-  // See https://reactnative.dev/docs/native-modules-android
   @ReactMethod
   override fun init(key: String, options: ReadableMap?) {
-    val apiUrl = options?.getString("url")
+    val apiUrl = options?.getString("url") ?: "https://api.bitdrift.io"
 
-    if (apiUrl != null) {
-      Capture.Logger.start(apiKey = key, apiUrl = apiUrl.toHttpUrl(), sessionStrategy = SessionStrategy.Fixed())
-    } else {
-      Capture.Logger.start(apiKey = key, sessionStrategy = SessionStrategy.Fixed())
-    }
+    Capture.Logger.start(apiKey = key, apiUrl = apiUrl.toHttpUrl(), sessionStrategy = SessionStrategy.Fixed())
   }
 
   @ReactMethod

--- a/packages/react-native/android/src/oldarch/BdReactNativeSpec.kt
+++ b/packages/react-native/android/src/oldarch/BdReactNativeSpec.kt
@@ -12,7 +12,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableMap
 
-abstract class BdReactNativeSpec internal constructor(context: ReactApplicationContext) :
+abstract class BdReactNativeSpec internal constructor(context: ReactApplicationContext):
   ReactContextBaseJavaModule(context) {
 
   abstract fun init(key: String, options: ReadableMap?)

--- a/packages/react-native/ios/BdReactNative.mm
+++ b/packages/react-native/ios/BdReactNative.mm
@@ -1,5 +1,6 @@
 #import "BdReactNative.h"
 #import "Capture/Capture.h"
+#import "bd_react_native-Swift.h"
 
 @implementation BdReactNative
 RCT_EXPORT_MODULE()
@@ -14,43 +15,26 @@ RCT_EXPORT_METHOD(log:(double)level
 #ifndef RCT_NEW_ARCH_ENABLED
 
 RCT_EXPORT_METHOD(init:(NSString*)apiKey
-      options:(NSDictionary*)options)
+  options:(NSDictionary*)options)
 {
-  NSString *apiURL = options[@"url"];
+  NSString* apiURL = options[@"url"];
+  BOOL enableNetworkInstrumentation = [options[@"enableNetworkInstrumentation"] boolValue];
 
-  if (apiURL != NULL) {
-    [CAPLogger
-      startWithAPIKey:apiKey
-      sessionStrategy:[CAPSessionStrategy activityBased]
-      apiURL:[NSURL URLWithString:apiURL]
-    ];
-  } else {
-    [CAPLogger
-      startWithAPIKey:apiKey
-      sessionStrategy:[CAPSessionStrategy activityBased]
-      apiURL:[NSURL URLWithString:@"https://api.bitdrift.io/"]
-    ];
-  }
+  [CAPRNLogger 
+    startWithKey:apiKey
+    url:apiURL
+    enableNetworkInstrumentation:enableNetworkInstrumentation
+  ];
 }
 
-#else
-
 RCT_EXPORT_METHOD(init:(NSString*)apiKey
-                  options:(JS::NativeBdReactNative::SpecInitOptions &)options)
+  options:(JS::NativeBdReactNative::SpecInitOptions &)options)
 {
-    if (options.url() != NULL) {
-        [CAPLogger
-         startWithAPIKey:apiKey
-         sessionStrategy:[CAPSessionStrategy activityBased]
-         apiURL:[NSURL URLWithString:options.url()]
-        ];
-    } else {
-        [CAPLogger
-         startWithAPIKey:apiKey
-         sessionStrategy:[CAPSessionStrategy activityBased]
-         apiURL:[NSURL URLWithString:@"https://api.bitdrift.io/"]
-        ];
-    }
+  [CAPRNLogger 
+    startWithKey:apiKey
+    url:options.url()
+    enableNetworkInstrumentation:options.enableNetworkInstrumentation()
+  ];
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/packages/react-native/ios/BdReactNative.mm
+++ b/packages/react-native/ios/BdReactNative.mm
@@ -32,10 +32,13 @@ RCT_EXPORT_METHOD(init:(NSString*)apiKey
 RCT_EXPORT_METHOD(init:(NSString*)apiKey
   options:(JS::NativeBdReactNative::SpecInitOptions &)options)
 {
-  [CAPRNLogger 
+  BOOL enableNetworkInstrumentation = options.enableNetworkInstrumentation().has_value() ?
+    options.enableNetworkInstrumentation().value() : false;
+
+  [CAPRNLogger
     startWithKey:apiKey
     url:options.url()
-    enableNetworkInstrumentation:options.enableNetworkInstrumentation()
+    enableNetworkInstrumentation:enableNetworkInstrumentation
   ];
 }
 

--- a/packages/react-native/ios/BdReactNative.mm
+++ b/packages/react-native/ios/BdReactNative.mm
@@ -27,6 +27,8 @@ RCT_EXPORT_METHOD(init:(NSString*)apiKey
   ];
 }
 
+#else
+
 RCT_EXPORT_METHOD(init:(NSString*)apiKey
   options:(JS::NativeBdReactNative::SpecInitOptions &)options)
 {

--- a/packages/react-native/ios/Logger.swift
+++ b/packages/react-native/ios/Logger.swift
@@ -12,7 +12,7 @@ import Capture
         let integrator = Capture.Logger.start(
             withAPIKey: key,
             sessionStrategy: SessionStrategy.fixed(),
-            apiURL: URL(string: url)!
+            apiURL: URL(string: url ?? "https://api.bitdrift.io")!
         )
 
         if enableNetworkInstrumentation {

--- a/packages/react-native/ios/Logger.swift
+++ b/packages/react-native/ios/Logger.swift
@@ -7,9 +7,17 @@
 
 import Capture
 
-@objc public class Logger: NSObject {
-    @objc public static func start(key: String, url: String) {
-        Capture.Logger.start(withAPIKey: key, sessionStrategy: SessionStrategy.fixed(), apiURL: URL(string: url)!)
+@objc public class CAPRNLogger: NSObject {
+    @objc public static func start(key: String, url: String?, enableNetworkInstrumentation: Bool) {
+        let integrator = Capture.Logger.start(
+            withAPIKey: key,
+            sessionStrategy: SessionStrategy.fixed(),
+            apiURL: URL(string: url)!
+        )
+
+        if enableNetworkInstrumentation {
+            integrator?.enableIntegrations([.urlSession()])
+        }
     }
 
     @objc

--- a/packages/react-native/src/NativeBdReactNative.ts
+++ b/packages/react-native/src/NativeBdReactNative.ts
@@ -11,7 +11,7 @@ import { TurboModuleRegistry } from 'react-native';
 export type LogFields = { [key: string]: string };
 
 export interface Spec extends TurboModule {
-  init(key: string, options?: { url?: string }): void;
+  init(key: string, options?: { url?: string, enableNetworkInstrumentation?: boolean }): void;
   log(level: number, message: string, fields?: LogFields): void;
 }
 

--- a/packages/react-native/src/index.tsx
+++ b/packages/react-native/src/index.tsx
@@ -24,7 +24,7 @@ const BdReactNative = BdReactNativeModule
         get() {
           throw new Error(LINKING_ERROR);
         },
-      },
+      }
     );
 
 export function init(

--- a/packages/react-native/src/index.tsx
+++ b/packages/react-native/src/index.tsx
@@ -24,11 +24,14 @@ const BdReactNative = BdReactNativeModule
         get() {
           throw new Error(LINKING_ERROR);
         },
-      }
+      },
     );
 
-export function init(key: string, options?: { url?: string }): void {
-  return BdReactNative.init(key, options);
+export function init(
+  key: string,
+  options?: { url?: string; enableNetworkInstrumentation?: boolean },
+): void {
+  return BdReactNative.init(key, options)
 }
 
 export function trace(message: string, fields?: LogFields): void {

--- a/packages/react-native/src/plugin/config.ts
+++ b/packages/react-native/src/plugin/config.ts
@@ -1,0 +1,10 @@
+// capture-es - bitdrift's ES SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+export default interface PluginProps {
+  networkInstrumentation?: boolean;
+}

--- a/packages/react-native/src/plugin/withAndroid.ts
+++ b/packages/react-native/src/plugin/withAndroid.ts
@@ -1,0 +1,89 @@
+// capture-es - bitdrift's ES SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+import { withPlugins } from '@expo/config-plugins';
+import { withAppBuildGradle, withSettingsGradle } from '@expo/config-plugins';
+import type { ConfigPlugin } from '@expo/config-plugins';
+import PluginProps from './config';
+
+const withBitdriftAppBuildGradle: ConfigPlugin<PluginProps | void> = (
+  config,
+  props,
+) => {
+  return withAppBuildGradle(config, (config) => {
+    if (!config.modResults.contents.includes('dl.bitdrift.io')) {
+      // TODO(snowp): Eventually we'd always install the plugin and gate the okhttp instrumentation
+      // config on the networkInstrumentation prop.
+      if (props && props.networkInstrumentation) {
+        // Add the capture-plugin at the very top of the file.
+        config.modResults.contents =
+          `plugins {
+    id 'io.bitdrift.capture-plugin' version '0.16.4'
+}
+
+` + config.modResults.contents;
+      }
+
+      // Define the bitdrift maven repository at the end. This is necessary to resolve the SDK dependency specified by the plugin.
+      config.modResults.contents += `
+
+repositories {
+    maven {
+        url 'https://dl.bitdrift.io/sdk/android-maven'
+        content {
+          includeGroup 'io.bitdrift'
+        }
+    }
+}
+`;
+    }
+
+    return config;
+  });
+};
+
+const withBitdriftSettingsGradle: ConfigPlugin<PluginProps | void> = (
+  config,
+  _props,
+) => {
+  // Add the bitdrift maven repository to the pluginManagement block to allow the plugin to resolve the SDK dependency. This is safe to do regardless of whether the network instrumentation is enabled or not.
+  return withSettingsGradle(config, (config) => {
+    if (!config.modResults.contents.includes('dl.bitdrift.io')) {
+      // There will be a pluginManagement block in the settings.gradle file already, so we need to insert ourselves
+      // into the existing block.
+      //
+      // Note that we use a regex here because we need to resolve both the `io.bitdrift` group as well as the
+      // `io.bitdrift.capture-plugin` group.
+      config.modResults.contents = config.modResults.contents.replace(
+        'pluginManagement {',
+        `pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+        maven {
+            url 'https://dl.bitdrift.io/sdk/android-maven'
+            content {
+                includeGroupByRegex "io\\.bitdrift.*"
+            }
+        }
+    } 
+`,
+      );
+    }
+
+    return config;
+  });
+};
+
+const withAndroid: ConfigPlugin<PluginProps | void> = (config, props) => {
+  return withPlugins(config, [
+    [withBitdriftAppBuildGradle, props],
+    [withBitdriftSettingsGradle, props],
+  ]);
+};
+
+export default withAndroid;

--- a/packages/react-native/src/plugin/withBitdrift.ts
+++ b/packages/react-native/src/plugin/withBitdrift.ts
@@ -5,21 +5,16 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-import { withAppBuildGradle } from '@expo/config-plugins';    
-import { ExpoConfig } from '@expo/config-types';
+import { withPlugins } from '@expo/config-plugins';
+import type { ConfigPlugin } from '@expo/config-plugins';
+import withAndroid from './withAndroid';
+import PluginProps from './config';
 
-module.exports = function withAndroidStrategiesPlugin(config: ExpoConfig) {
-    return withAppBuildGradle(config, (config) => {
-        config.modResults.contents += `
-repositories {
-  maven {
-    url 'https://dl.bitdrift.io/sdk/android-maven'
-    content {
-      includeGroup 'io.bitdrift'
-    }
-  }
-}
-        `;
-        return config;
-      });
-}
+const withBitdriftPlugin: ConfigPlugin<PluginProps | void> = (
+  config,
+  props,
+) => {
+  return withPlugins(config, [[withAndroid, props]]);
+};
+
+export default withBitdriftPlugin;

--- a/scripts/license_header.py
+++ b/scripts/license_header.py
@@ -25,6 +25,7 @@ exclude_dirs = (
     './.git',
     './target/',
     './examples/',
+    './node_modules/',
 )
 
 extensions_to_check = ('.rs', '.toml', '.kt', '.java', '.swift', '.ts', '.js')


### PR DESCRIPTION
This adds support for enabling the iOS and Android network integration via the expo plugin. 

For Android, the `enableNetworkInstrumentation` Expo plugin property must be set. This brings in the gradle plugin which auto-instruments OkHttp.
For iOS, the `enableNetworkInstrumentation` parameter must be set when calling `init`. This enables the swizzling-based instrumentation of UrlSession

Having two separate configuration mechanisms is a bit ugly but should get us started, we can then refine this down the line