### PR TITLE
rn: fix old arch issues introduced in v0.6.0

### DIFF
--- a/packages/react-native/BdReactNative.podspec
+++ b/packages/react-native/BdReactNative.podspec
@@ -5,7 +5,7 @@ folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 
 capture_version = '0.16.6'
 
 Pod::Spec.new do |s|
-  s.name         = "bd-react-native"
+  s.name         = "BdReactNative"
   s.version      = package["version"]
   s.summary      = package["description"]
   s.homepage     = package["homepage"]

--- a/packages/react-native/android/src/oldarch/BdReactNativeSpec.kt
+++ b/packages/react-native/android/src/oldarch/BdReactNativeSpec.kt
@@ -20,4 +20,6 @@ abstract class BdReactNativeSpec internal constructor(context: ReactApplicationC
   abstract fun getDeviceID(promise: Promise)
 
   abstract fun log(level: Double, message: String, jsFields: ReadableMap?)
+
+  abstract fun addField(key: String, value: String)
 }

--- a/packages/react-native/ios/BdReactNative.mm
+++ b/packages/react-native/ios/BdReactNative.mm
@@ -1,6 +1,6 @@
 #import "BdReactNative.h"
 #import "Capture/Capture.h"
-#import "bd_react_native-Swift.h"
+#import "BdReactNative-Swift.h"
 
 @implementation BdReactNative
 RCT_EXPORT_MODULE()

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitdrift/react-native",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "bitdrift integration for React Native",
   "main": "dist/commonjs/index",
   "module": "dist/module/index",


### PR DESCRIPTION
- On android we were missing an interface definition that is only required on the old arch
- On iOS we ran into an issue with the way the Swift header was generated due to how it attempts to transform the pod name into a header name 