### PR TITLE
electron: fix error reporter

### DIFF
--- a/packages/core/Cargo.lock
+++ b/packages/core/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -246,7 +246,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -319,7 +319,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "bd-proto",
  "bd-stats-common",
@@ -333,7 +333,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "log",
@@ -343,7 +343,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "bd-runtime",
  "bd-shutdown",
@@ -372,7 +372,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -413,7 +413,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "base64",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-time",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -512,7 +512,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -595,7 +595,7 @@ dependencies = [
 [[package]]
 name = "bd-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "base64",
@@ -623,12 +623,12 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "log",
  "protobuf",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "bd-pgv",
  "bytes",
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-internal-logging",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime-config"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "async-trait",
  "bd-server-stats",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "bd-stats-common",
  "bd-time",
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "log",
  "tokio",
@@ -770,12 +770,12 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core#9acd7aa44c7eb718c475c33564021344c16c2151"
+source = "git+https://github.com/bitdriftlabs/shared-core#6e08e08ba659ac710458723f9d9614a754e15577"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -900,9 +900,9 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
 dependencies = [
  "shlex",
 ]
@@ -1618,9 +1618,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -1896,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]

--- a/packages/core/src/logger.rs
+++ b/packages/core/src/logger.rs
@@ -17,6 +17,7 @@
 mod integration_test;
 
 use crate::SessionStrategy;
+use bd_client_common::error::handle_unexpected;
 use bd_key_value::Storage;
 use bd_logger::{
   AnnotatedLogField,
@@ -137,13 +138,11 @@ impl RustLogger {
     .build()?;
 
     LoggerBuilder::run_logger_runtime(async {
-      // Make sure we hold onto the shutdown handle to avoid an immediate shutdown.
+      // // Make sure we hold onto the shutdown handle to avoid an immediate shutdown.
       #[allow(clippy::no_effect_underscore_binding)]
       let _shutdown = shutdown;
 
-      handle_unexpected::<(), _>(Err(anyhow::anyhow!("test")), "test");
-
-      // Since the error reporting relie on the reporter future we need to make sure that we give
+      // Since the error reporting relies on the reporter future we need to make sure that we give
       // the reporter a chance to report on the error returned from the top level task. To
       // accomplish this we run the reporter in a separate task that we allow to finish after the
       // logger future has completed.

--- a/packages/core/src/logger.rs
+++ b/packages/core/src/logger.rs
@@ -138,7 +138,7 @@ impl RustLogger {
     .build()?;
 
     LoggerBuilder::run_logger_runtime(async {
-      // // Make sure we hold onto the shutdown handle to avoid an immediate shutdown.
+      // Make sure we hold onto the shutdown handle to avoid an immediate shutdown.
       #[allow(clippy::no_effect_underscore_binding)]
       let _shutdown = shutdown;
 

--- a/scripts/swap_local.sh
+++ b/scripts/swap_local.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Run this to swap all of the deps to a local version for easy development.
+for crate in bd-client-common bd-device bd-events bd-grpc bd-grpc-codec bd-hyper-network bd-key-value \
+  bd-log bd-logger bd-matcher bd-metadata bd-panic bd-pgv bd-profile bd-proto bd-proto-util \
+  bd-resource-utilization bd-rt bd-runtime-config bd-server-stats bd-session bd-session-replay \
+  bd-shutdown bd-test-helpers bd-time; do
+  /usr/bin/sed -i '' "s/\(${crate}\)[[:space:]]*=.*/\\1\.path = \"\.\.\/\.\.\/\.\.\/shared-core\/\\1\"/g" packages/core/Cargo.toml
+done


### PR DESCRIPTION
- Bring in latest changes which fixes the headers set on error reports
- Rework the futures a bit to avoid a failure in the core tasks from shutting down the reporter future