### PR TITLE
react native: fix ios on new architecture

### DIFF
--- a/packages/react-native/ios/BdReactNative.h
+++ b/packages/react-native/ios/BdReactNative.h
@@ -1,6 +1,6 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
-#import "NativeBdReactNativeSpec/NativeBdReactNativeSpec.h"
+#import "RNBdReactNativeSpec/RNBdReactNativeSpec.h"
 
 @interface BdReactNative : NSObject <NativeBdReactNativeSpec>
 #else

--- a/packages/react-native/ios/BdReactNative.mm
+++ b/packages/react-native/ios/BdReactNative.mm
@@ -18,6 +18,23 @@ RCT_EXPORT_METHOD(addField:(NSString*)key
     [CAPRNLogger addField:key value:value];
 }
 
+#ifndef RCT_NEW_ARCH_ENABLED
+
+RCT_EXPORT_METHOD(init:(NSString*)apiKey
+  sessionStrategy:(NSString*)sessionStrategy
+  options:(NSDictionary*)options)
+{
+  NSString* apiURL = options[@"url"];
+  BOOL enableNetworkInstrumentation = [options[@"enableNetworkInstrumentation"] boolValue];
+
+  [CAPRNLogger
+    startWithKey:apiKey
+    sessionStrategy:sessionStrategy
+    url:apiURL
+    enableNetworkInstrumentation:enableNetworkInstrumentation
+  ];
+}
+
 RCT_EXPORT_METHOD(getDeviceID:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -35,28 +52,12 @@ RCT_EXPORT_METHOD(getDeviceID:(RCTPromiseResolveBlock)resolve
   }];
 }
 
-#ifndef RCT_NEW_ARCH_ENABLED
-
-RCT_EXPORT_METHOD(init:(NSString*)apiKey
-  sessionStrategy:(NSString*)sessionStrategy
-  options:(NSDictionary*)options)
-{
-  NSString* apiURL = options[@"url"];
-  BOOL enableNetworkInstrumentation = [options[@"enableNetworkInstrumentation"] boolValue];
-
-  [CAPRNLogger 
-    startWithKey:apiKey
-    sessionStrategy:sessionStrategy
-    url:apiURL
-    enableNetworkInstrumentation:enableNetworkInstrumentation
-  ];
-}
 
 #else
 
 RCT_EXPORT_METHOD(init:(NSString*)apiKey
   sessionStrategy:(NSString*)sessionStrategy
-  options:(JS::NativeBdReactNative::SpecInitOptions &)options)
+  options:(JS::NativeBdReactNative::InitOptions& )options)
 {
   BOOL enableNetworkInstrumentation = options.enableNetworkInstrumentation().has_value() ?
     options.enableNetworkInstrumentation().value() : false;
@@ -67,6 +68,21 @@ RCT_EXPORT_METHOD(init:(NSString*)apiKey
     url:options.url()
     enableNetworkInstrumentation:enableNetworkInstrumentation
   ];
+}
+
+- (void)getDeviceID:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+    [CAPRNLogger getDeviceID:^(NSString *deviceID) {
+      if (deviceID == nil || [deviceID isEqual:[NSNull null]] || [deviceID isEqualToString:@""]) {
+        NSError *error = [NSError errorWithDomain:@"CAPRNLogger"
+                                             code:404
+                                         userInfo:@{NSLocalizedDescriptionKey: @"Device ID is undefined"}];
+        reject(@"device_id_undefined", @"Device ID is undefined", error);
+      } else {
+        resolve(deviceID);
+      }
+    } rejecter:^(NSString *code, NSString *message, NSError *error) {
+      reject(code, message, error);
+    }];
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitdrift/react-native",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "bitdrift integration for React Native",
   "main": "dist/commonjs/index",
   "module": "dist/module/index",


### PR DESCRIPTION
Turns out the expo hello world app does not fully enable the new arch. Manually ran it as new arch and fixed the build issues 