### PR TITLE
react native: handle the case when no options are provided

### DIFF
--- a/packages/react-native/ios/BdReactNative.mm
+++ b/packages/react-native/ios/BdReactNative.mm
@@ -59,8 +59,7 @@ RCT_EXPORT_METHOD(init:(NSString*)apiKey
   sessionStrategy:(NSString*)sessionStrategy
   options:(JS::NativeBdReactNative::InitOptions& )options)
 {
-  BOOL enableNetworkInstrumentation = options.enableNetworkInstrumentation().has_value() ?
-    options.enableNetworkInstrumentation().value() : false;
+  BOOL enableNetworkInstrumentation = options != nil && options.enableNetworkInstrumentation().has_value() ? options.enableNetworkInstrumentation().value() : false;
 
   [CAPRNLogger
     startWithKey:apiKey


### PR DESCRIPTION
In the old arch options["foo"] would happily return nil when options was nil, but in the new world options.foo() blows up if options is nil so we need an extra check