### PR TITLE
react native: update Capture SDK to 0.16.10

### DIFF
--- a/examples/expo/app.config.ts
+++ b/examples/expo/app.config.ts
@@ -3,6 +3,7 @@ const newArchEnabled = process.env.NEW_ARCH !== 'false';
 export default {
   expo: {
     name: 'ExpoExample',
+    newArchEnabled: newArchEnabled,
     slug: 'expo-example',
     entryPoint: 'expo-router/entry',
     version: '1.0.0',

--- a/examples/expo/src/app/App.tsx
+++ b/examples/expo/src/app/App.tsx
@@ -33,7 +33,7 @@ const LOG_LEVELS = new Map([
 
 const hasAPIKeyConfigured = Boolean(
   process.env.EXPO_PUBLIC_BITDRIFT_API_KEY &&
-    process.env.EXPO_PUBLIC_BITDRIFT_API_URL,
+  process.env.EXPO_PUBLIC_BITDRIFT_API_URL,
 );
 
 const sendRandomRequest = async () => {

--- a/examples/expo/src/lib/bitdrift.ts
+++ b/examples/expo/src/lib/bitdrift.ts
@@ -1,4 +1,4 @@
-import { init, addField, debug, SessionStrategy } from '@bitdrift/react-native';
+import { init, addField, debug, getDeviceID, getSessionID, getSessionURL, SessionStrategy } from '@bitdrift/react-native';
 
 const BITDRIFT_API_KEY = process.env.EXPO_PUBLIC_BITDRIFT_API_KEY;
 const BITDRIFT_API_URL = process.env.EXPO_PUBLIC_BITDRIFT_API_URL;
@@ -8,6 +8,19 @@ if (BITDRIFT_API_KEY && BITDRIFT_API_URL) {
     url: BITDRIFT_API_URL,
     enableNetworkInstrumentation: true,
   });
+
+  getSessionID().then((sessionID) => {
+    console.log('Session ID:', sessionID);
+  });
+
+  getSessionURL().then((sessionURL) => {
+    console.log('Session URL:', sessionURL);
+  });
+
+  getDeviceID().then((deviceID) => {
+    console.log('Device ID:', deviceID);
+  });
+
   addField('environment', 'expo');
   debug('expo example initialized');
 }

--- a/packages/react-native/BdReactNative.podspec
+++ b/packages/react-native/BdReactNative.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-capture_version = '0.16.9'
+capture_version = '0.16.10'
 
 Pod::Spec.new do |s|
   s.name         = "BdReactNative"

--- a/packages/react-native/BdReactNative.podspec
+++ b/packages/react-native/BdReactNative.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-capture_version = '0.16.6'
+capture_version = '0.16.9'
 
 Pod::Spec.new do |s|
   s.name         = "BdReactNative"

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -53,10 +53,6 @@ android {
     }
   }
 
-  kotlinOptions {
-    freeCompilerArgs += ["-Xskip-metadata-version-check"]
-  }
-
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -53,6 +53,10 @@ android {
     }
   }
 
+  kotlinOptions {
+    freeCompilerArgs += ["-Xskip-metadata-version-check"]
+  }
+
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
@@ -112,7 +116,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  api 'io.bitdrift:capture:0.16.6'
+  api 'io.bitdrift:capture:0.16.9'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -116,7 +116,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  api 'io.bitdrift:capture:0.16.9'
+  api 'io.bitdrift:capture:0.16.10'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/packages/react-native/src/plugin/withAndroid.ts
+++ b/packages/react-native/src/plugin/withAndroid.ts
@@ -22,7 +22,7 @@ const withBitdriftAppBuildGradle: ConfigPlugin<PluginProps | void> = (
         // Add the capture-plugin at the very top of the file.
         config.modResults.contents =
           `plugins {
-    id 'io.bitdrift.capture-plugin' version '0.16.9'
+    id 'io.bitdrift.capture-plugin' version '0.16.10'
 }
 
 ` + config.modResults.contents;

--- a/packages/react-native/src/plugin/withAndroid.ts
+++ b/packages/react-native/src/plugin/withAndroid.ts
@@ -22,7 +22,7 @@ const withBitdriftAppBuildGradle: ConfigPlugin<PluginProps | void> = (
         // Add the capture-plugin at the very top of the file.
         config.modResults.contents =
           `plugins {
-    id 'io.bitdrift.capture-plugin' version '0.16.6'
+    id 'io.bitdrift.capture-plugin' version '0.16.9'
 }
 
 ` + config.modResults.contents;

--- a/scripts/update_rn_capture_version.sh
+++ b/scripts/update_rn_capture_version.sh
@@ -11,6 +11,6 @@ sed -i "s/capture_version = '.*/capture_version = '$version'/g" packages/react-n
 sed -i "s/id 'io.bitdrift.capture-plugin' version '.*/id 'io.bitdrift.capture-plugin' version '$version'/g" packages/react-native/src/plugin/withAndroid.ts
 
 # Replace `api 'io.bitdrift.capture:0.16.5'` with the new version number
-sed -i "s/api 'io.bitdrift.capture:.*/api 'io.bitdrift.capture:$version'/g" packages/react-native/android/build.gradle
+sed -i "s/api 'io\.bitdrift\.capture:.*/api 'io.bitdrift:capture:$version'/g" packages/react-native/android/build.gradle
 
 

--- a/scripts/update_rn_capture_version.sh
+++ b/scripts/update_rn_capture_version.sh
@@ -11,6 +11,6 @@ sed -i "s/capture_version = '.*/capture_version = '$version'/g" packages/react-n
 sed -i "s/id 'io.bitdrift.capture-plugin' version '.*/id 'io.bitdrift.capture-plugin' version '$version'/g" packages/react-native/src/plugin/withAndroid.ts
 
 # Replace `api 'io.bitdrift.capture:0.16.5'` with the new version number
-sed -i "s/api 'io\.bitdrift\.capture:.*/api 'io.bitdrift:capture:$version'/g" packages/react-native/android/build.gradle
+sed -i "s/api 'io\.bitdrift:capture:.*/api 'io.bitdrift:capture:$version'/g" packages/react-native/android/build.gradle
 
 


### PR DESCRIPTION
- Updates the Capture SDK to 0.16.10
- Ensure test coverage for get* JS calls in expo hello world app
- Try to address new arch not being picked up in the iOS expo hw app