### PR TITLE
[React] Bump capture sdk changes from 0.16.11 to 0.17.5

### DIFF
--- a/packages/react-native/BdReactNative.podspec
+++ b/packages/react-native/BdReactNative.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-capture_version = '0.17.1'
+capture_version = '0.17.5'
 
 Pod::Spec.new do |s|
   s.name         = "BdReactNative"

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -112,7 +112,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  api 'io.bitdrift:capture:0.16.11'
+  api 'io.bitdrift:capture:0.17.5'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/packages/react-native/src/plugin/withAndroid.ts
+++ b/packages/react-native/src/plugin/withAndroid.ts
@@ -22,7 +22,7 @@ const withBitdriftAppBuildGradle: ConfigPlugin<PluginProps | void> = (
         // Add the capture-plugin at the very top of the file.
         config.modResults.contents =
           `plugins {
-    id 'io.bitdrift.capture-plugin' version '0.16.11'
+    id 'io.bitdrift.capture-plugin' version '0.17.5'
 }
 
 ` + config.modResults.contents;


### PR DESCRIPTION
Bump capture sdk changes from 0.16.11 to 0.17.5. This will be released as 0.6.9

Release notes are being updated at https://github.com/bitdriftlabs/bitdrift-docs/pull/260/files