### PR TITLE
don't fail test when cleanup operation fails

### DIFF
--- a/packages/core/index.spec.ts
+++ b/packages/core/index.spec.ts
@@ -29,8 +29,13 @@ describe('bitdrift native logger', () => {
   });
 
   afterAll(() => {
-    if (fs.existsSync('./store')) {
-      fs.rmSync('./store', { recursive: true, force: true });
+    try {
+      if (fs.existsSync('./store')) {
+        fs.rmSync('./store', { recursive: true, force: true });
+      }
+    } catch (error) {
+      console.warn('Failed to clean up store directory:', error);
+      // Continue test teardown even if cleanup fails
     }
   });
 


### PR DESCRIPTION
Instead of failing when the cleanup task fails just log a warning. This seems to happen at times for version bump PRs for some reason