### PR TITLE
Update maestro tests 

### DIFF
--- a/.github/workflows/react-native-e2e.yml
+++ b/.github/workflows/react-native-e2e.yml
@@ -60,8 +60,13 @@ jobs:
         run: npm exec nx prebuild expo-example
         env:
           NEW_ARCH: ${{ matrix.settings.new_arch }}
+          EXPO_PUBLIC_BITDRIFT_API_KEY: ${{ secrets.BITDRIFT_API_KEY }}
+          EXPO_PUBLIC_BITDRIFT_API_URL: ${{ secrets.BITDRIFT_API_URL }}
       - name: Serve Expo
         run: npm exec nx start expo-example > /tmp/expo_logs &
+        env:
+          EXPO_PUBLIC_BITDRIFT_API_KEY: ${{ secrets.BITDRIFT_API_KEY }}
+          EXPO_PUBLIC_BITDRIFT_API_URL: ${{ secrets.BITDRIFT_API_URL }}
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -69,6 +74,8 @@ jobs:
           script: cd examples/expo/android && ./gradlew installDebug --build-cache -PreactNativeDevServerPort=19000 -PreactNativeArchitectures=x86 && maestro test ../maestro_flow.yaml
         env:
           MAESTRO_CLI_NO_ANALYTICS: true
+          EXPO_PUBLIC_BITDRIFT_API_KEY: ${{ secrets.BITDRIFT_API_KEY }}
+          EXPO_PUBLIC_BITDRIFT_API_URL: ${{ secrets.BITDRIFT_API_URL }}
       - name: Upload Maestro artifacts
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/react-native-e2e.yml
+++ b/.github/workflows/react-native-e2e.yml
@@ -56,17 +56,17 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+      - name: Create .env file
+        run: |
+          cd examples/expo
+          echo "EXPO_PUBLIC_BITDRIFT_API_KEY=${{ secrets.BITDRIFT_API_KEY }}" > .env
+          echo "EXPO_PUBLIC_BITDRIFT_API_URL=${{ secrets.BITDRIFT_API_URL }}" >> .env
       - name: Prebuild
         run: npm exec nx prebuild expo-example
         env:
           NEW_ARCH: ${{ matrix.settings.new_arch }}
-          EXPO_PUBLIC_BITDRIFT_API_KEY: ${{ secrets.BITDRIFT_API_KEY }}
-          EXPO_PUBLIC_BITDRIFT_API_URL: ${{ secrets.BITDRIFT_API_URL }}
       - name: Serve Expo
         run: npm exec nx start expo-example > /tmp/expo_logs &
-        env:
-          EXPO_PUBLIC_BITDRIFT_API_KEY: ${{ secrets.BITDRIFT_API_KEY }}
-          EXPO_PUBLIC_BITDRIFT_API_URL: ${{ secrets.BITDRIFT_API_URL }}
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -74,8 +74,6 @@ jobs:
           script: cd examples/expo/android && ./gradlew installDebug --build-cache -PreactNativeDevServerPort=19000 -PreactNativeArchitectures=x86 && maestro test ../maestro_flow.yaml
         env:
           MAESTRO_CLI_NO_ANALYTICS: true
-          EXPO_PUBLIC_BITDRIFT_API_KEY: ${{ secrets.BITDRIFT_API_KEY }}
-          EXPO_PUBLIC_BITDRIFT_API_URL: ${{ secrets.BITDRIFT_API_URL }}
       - name: Upload Maestro artifacts
         uses: actions/upload-artifact@v4
         if: failure()

--- a/examples/expo/src/app/App.tsx
+++ b/examples/expo/src/app/App.tsx
@@ -92,22 +92,24 @@ const HomeScreen = () => {
         />
       )}
 
-      <View style={styles.inlineContainer}>
-        <Pressable
-          style={({ pressed }) => [
-            styles.button,
-            pressed && styles.buttonActive,
-          ]}
-          onPress={handleGenerateTemporaryDeviceCode}
-        >
-          <Text style={styles.buttonText}>Generate Temporary Device Code</Text>
-        </Pressable>
-        {temporaryDeviceCode && (
-          <Text selectable style={{ margin: 10 }}>
-            {temporaryDeviceCode}
-          </Text>
-        )}
-      </View>
+      {hasAPIKeyConfigured && (
+        <View style={styles.inlineContainer}>
+          <Pressable
+            style={({ pressed }) => [
+              styles.button,
+              pressed && styles.buttonActive,
+            ]}
+            onPress={handleGenerateTemporaryDeviceCode}
+          >
+            <Text style={styles.buttonText}>Generate Temporary Device Code</Text>
+          </Pressable>
+          {temporaryDeviceCode && (
+            <Text selectable style={{ margin: 10 }}>
+              {temporaryDeviceCode}
+            </Text>
+          )}
+        </View>
+      )}
 
       <Pressable
         style={({ pressed }) => [styles.button, pressed && styles.buttonActive]}


### PR DESCRIPTION
- Updating maestro tests for Android to fail if the generated code button is not visible
- Updating ci to set the .env values for proper capture sdk initialization

### Verification

Locally with empty env for url/api key

<img width="469" height="196" alt="image" src="https://github.com/user-attachments/assets/d838fd64-1be1-4ce4-afdf-6de82b8fd267" />

Verify on ci

<img width="752" height="275" alt="image" src="https://github.com/user-attachments/assets/ed1647a4-4714-447b-b0f0-e6ac342f823c" />
