### PR TITLE
[React] Release pipeline fixes

### DIFF
--- a/.github/workflows/react-native-auto-release-after-capture-sdk-version-bump.yml
+++ b/.github/workflows/react-native-auto-release-after-capture-sdk-version-bump.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   auto-publish:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.title, 'Update Capture SDK to') && github.event.pull_request.user.login == 'github-actions[bot]'
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.title, 'Update Capture SDK version to') && github.event.pull_request.user.login == 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/react-native-auto-release-after-capture-sdk-version-bump.yml
+++ b/.github/workflows/react-native-auto-release-after-capture-sdk-version-bump.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   auto-publish:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.title, 'Update React Native version with Capture SDK') && github.event.pull_request.user.login == 'github-actions[bot]'
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.title, 'Update Capture SDK to') && github.event.pull_request.user.login == 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,13 +18,20 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/javascript-setup
         
-      - name: Get React Native version from package.json
+      - name: Read expected React Native version from file
         id: extract-version
         run: |
-          # Get the current version from package.json after the PR is merged
-          CURRENT_RN_VERSION=$(node -p "require('./packages/react-native/package.json').version")
-          echo "rn_version=$CURRENT_RN_VERSION" >> $GITHUB_OUTPUT
-          echo "Current React Native version from package.json: $CURRENT_RN_VERSION"
+          if [ -f ".auto-release-react-version" ]; then
+            RN_VERSION=$(cat .auto-release-react-version | tr -d '\n\r')
+            echo "Read expected React Native version from file: $RN_VERSION"
+          else
+            echo "ERROR: .auto-release-react-version file not found!"
+            echo "This should have been created by the update workflow"
+            exit 1
+          fi
+          
+          echo "rn_version=$RN_VERSION" >> $GITHUB_OUTPUT
+          echo "Using React Native version: $RN_VERSION"
                     
       - name: Trigger React Native release workflow
         uses: actions/github-script@v7

--- a/.github/workflows/react-native-update-capture-sdk-version.yaml
+++ b/.github/workflows/react-native-update-capture-sdk-version.yaml
@@ -92,7 +92,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "Update Capture SDK to ${{ inputs.version }}"
-          commit-message: Update Capture SDK to ${{ inputs.version }}
+          commit-message: Update Capture SDK version to ${{ inputs.version }}
           committer: GitHub Action <noreply@github.com>
           base: main
           delete-branch: true

--- a/.github/workflows/react-native-update-capture-sdk-version.yaml
+++ b/.github/workflows/react-native-update-capture-sdk-version.yaml
@@ -85,28 +85,26 @@ jobs:
           
           NEW_RN_VERSION="$NEW_RN_MAJOR.$NEW_RN_MINOR.$NEW_RN_PATCH"
           echo "new_rn_version=$NEW_RN_VERSION" >> $GITHUB_OUTPUT
+          echo "Calculated new React Native version: $NEW_RN_VERSION"
 
-      - name: Update React Native package version
-        run: |
-          NEW_VERSION="${{ steps.update-rn-version.outputs.new_rn_version }}"
-          
-          # Update package.json
-          npm version $NEW_VERSION --workspace=packages/react-native --no-git-tag-version
-          
-          # Update package-lock.json
-          npm install --package-lock-only
-          
-          echo "Updated React Native package version to $NEW_VERSION"
-
-      - name: Create Pull Request after successful E2E tests
+      - name: Create Pull Request with Capture SDK version bump
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          title: Update version to ${{ inputs.version }} and bump React Native to ${{ steps.update-rn-version.outputs.new_rn_version }}
-          commit-message: Update React Native version with Capture SDK ${{ inputs.version }} and bump RN package to ${{ steps.update-rn-version.outputs.new_rn_version }}
+          title: "Update Capture SDK to ${{ inputs.version }}"
+          commit-message: Update Capture SDK to ${{ inputs.version }}
           committer: GitHub Action <noreply@github.com>
           base: main
           delete-branch: true
-          branch: update-rn-capture-version-${{ inputs.version }}
+          branch: update-capture-sdk-${{ inputs.version }}
+          body: |
+            This PR updates the Capture SDK to version ${{ inputs.version }}.
+            
+            https://github.com/bitdriftlabs/capture-sdk/releases/tag/v${{ inputs.version }}
+
+      - name: Store expected React Native version for auto-release
+        run: |
+          echo "${{ steps.update-rn-version.outputs.new_rn_version }}" > .auto-release-react-version
+          echo "Stored expected React Native version: ${{ steps.update-rn-version.outputs.new_rn_version }}"
 
 


### PR DESCRIPTION
The current release flow was tested yesterday and was missing a few things:

1. We shouldn't increment the react native version within `react-native-update-capture-sdk-version.yml` as the `react-native-release.yml` will create a PR that will increment those. 
2. Stores a the expected react version of auto release flow
3. Fixes expected title within `react-native-auto-release-after-capture-sdk-version-bump.yml` to auto trigger  `react-native-release.yml` with the calculated version