### PR TITLE
Fix small typo to trigger auto release action

### DIFF
--- a/.github/workflows/react-native-update-capture-sdk-version.yaml
+++ b/.github/workflows/react-native-update-capture-sdk-version.yaml
@@ -91,7 +91,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          title: "Update Capture SDK to ${{ inputs.version }}"
+          title: "Update Capture SDK version to ${{ inputs.version }}"
           commit-message: Update Capture SDK version to ${{ inputs.version }}
           committer: GitHub Action <noreply@github.com>
           base: main


### PR DESCRIPTION
`react-native-auto-release-after-capture-sdk-version-bump.yml` didn't trigger because of this so that release job had to be triggered manually