### PR TITLE
Fix RN release

### DIFF
--- a/.github/workflows/react-native-release.yml
+++ b/.github/workflows/react-native-release.yml
@@ -30,7 +30,7 @@ jobs:
           npm version --workspace @bitdrift/react-native $VERSION
           npx nx prepare-release @bitdrift/react-native
       - name: Publish release
-        run: npm publish ./dist/react-native --provenance --access public
+        run: npm publish ./dist/react-native --provenance
       - name: Create a PR with the updated version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See [recent announcement](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/)

Using https://docs.npmjs.com/generating-provenance-statements also see  https://docs.npmjs.com/trusted-publishers