### PR TITLE
Bring API parity (webview support for Android, getSdkStatus, startResult callback)

### DIFF
--- a/examples/expo/app.config.ts
+++ b/examples/expo/app.config.ts
@@ -38,6 +38,7 @@ export default {
         '../../dist/react-native/app.plugin.js', // In a real project, this would be '@bitdrift/react-native'
         {
           networkInstrumentation: true,
+          UNSTABLE_webViewInstrumentation: true,
         },
       ],
       [

--- a/examples/expo/package.json
+++ b/examples/expo/package.json
@@ -12,6 +12,7 @@
     "react": "18.2.0",
     "react-native": "*",
     "react-native-svg": "*",
+    "react-native-webview": "*",
     "react-native-web": "*"
   },
   "scripts": {

--- a/examples/expo/src/app/App.spec.tsx
+++ b/examples/expo/src/app/App.spec.tsx
@@ -5,5 +5,6 @@ import App from './App';
 
 test('renders correctly', () => {
   const { getByTestId } = render(<App />);
-  expect(getByTestId('heading')).toHaveTextContent('Welcome');
+  expect(getByTestId('sdk-status')).toBeTruthy();
+  expect(getByTestId('sdk-initialization-state')).toBeTruthy();
 });

--- a/examples/expo/src/app/App.tsx
+++ b/examples/expo/src/app/App.tsx
@@ -13,10 +13,13 @@ import {
   Alert,
   Modal,
   Platform,
+  ScrollView,
 } from 'react-native';
+import { WebView } from 'react-native-webview';
 import {
   generateDeviceCode,
   getPreviousRunInfo,
+  getSdkStatus,
   getSessionURL,
   info,
   debug,
@@ -26,6 +29,7 @@ import {
   logScreenView,
   logAppLaunchTTI,
   type PreviousRunInfo,
+  type SdkStatus,
   setFeatureFlagExposure,
 } from '@bitdrift/react-native';
 import axios from 'axios';
@@ -110,17 +114,25 @@ const HomeScreen = () => {
     null,
   );
   const [sessionURL, setSessionURL] = useState<string | null>(null);
+  const [sdkStatus, setSdkStatus] = useState<SdkStatus | null>(null);
   const [previousRunInfo, setPreviousRunInfo] = useState<PreviousRunInfo>(null);
   const [showPickerModal, setShowPickerModal] = useState(false);
   const [showErrorPickerModal, setShowErrorPickerModal] = useState(false);
+  const [showWebViewModal, setShowWebViewModal] = useState(false);
 
   useEffect(() => {
     setPreviousRunInfo(getPreviousRunInfo());
+    setSdkStatus(getSdkStatus());
 
     getSessionURL()
       .then(setSessionURL)
       .catch(() => {});
   }, []);
+
+  const refreshSdkStatus = () => {
+    setSdkStatus(getSdkStatus());
+    showToast(`SDK state: ${getSdkStatus().initializationState}`);
+  };
 
   const logMessageHandler = () => {
     if (selectedLogLevel) {
@@ -131,6 +143,7 @@ const HomeScreen = () => {
 
       logScreenView('HomeScreen');
       logAppLaunchTTI(1.0);
+      setSdkStatus(getSdkStatus());
       showToast(`Logged: [${selectedLogLevel.toUpperCase()}]: Log emitted`);
     }
   };
@@ -160,13 +173,19 @@ const HomeScreen = () => {
   };
 
   return (
-    <View style={styles.container}>
+    <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>
         @bitdrift/react-native Expo Integration Example
       </Text>
 
       <Text testID="sdk-status">
         {sessionURL ? 'SDK Ready' : 'SDK Not Ready'}
+      </Text>
+      <Text testID="sdk-initialization-state" style={styles.previousRunInfoText}>
+        SDK initialization state: {sdkStatus?.initializationState ?? 'unknown'}
+      </Text>
+      <Text style={styles.previousRunInfoText}>
+        SDK status: {JSON.stringify(sdkStatus)}
       </Text>
       <Text testID="previous-run-info" style={styles.previousRunInfoText}>
         Previous run info: {JSON.stringify(previousRunInfo)}
@@ -203,6 +222,16 @@ const HomeScreen = () => {
           styles.button,
           pressed && styles.buttonActive,
         ]}
+        onPress={refreshSdkStatus}
+      >
+        <Text style={styles.buttonText}>Refresh SDK Status</Text>
+      </Pressable>
+
+      <Pressable
+        style={({ pressed }) => [
+          styles.button,
+          pressed && styles.buttonActive,
+        ]}
         onPress={handleCopySessionURL}
       >
         <Text style={styles.buttonText}>Copy Session URL</Text>
@@ -214,6 +243,18 @@ const HomeScreen = () => {
       >
         <Text style={styles.buttonText}>Send Random REST Request</Text>
       </Pressable>
+
+      <View style={styles.buttonRow}>
+        <Pressable
+          style={({ pressed }) => [
+            styles.button,
+            pressed && styles.buttonActive,
+          ]}
+          onPress={() => setShowWebViewModal(true)}
+        >
+          <Text style={styles.buttonText}>Open bitdrift.io WebView</Text>
+        </Pressable>
+      </View>
 
       <View style={styles.pickerContainer}>
         <Text style={styles.pickerLabel}>Log Level:</Text>
@@ -405,7 +446,30 @@ const HomeScreen = () => {
         </Pressable>
       </View>
 
-    </View>
+      <Modal
+        visible={showWebViewModal}
+        animationType="slide"
+        presentationStyle="fullScreen"
+        onRequestClose={() => setShowWebViewModal(false)}
+      >
+        <SafeAreaView style={styles.webViewContainer}>
+          <View style={styles.webViewHeader}>
+            <Pressable
+              style={({ pressed }) => [
+                styles.button,
+                styles.webViewCloseButton,
+                pressed && styles.buttonActive,
+              ]}
+              onPress={() => setShowWebViewModal(false)}
+            >
+              <Text style={styles.buttonText}>Close WebView</Text>
+            </Pressable>
+          </View>
+          <WebView source={{ uri: 'https://bitdrift.io/' }} style={styles.webView} />
+        </SafeAreaView>
+      </Modal>
+
+    </ScrollView>
   );
 };
 
@@ -426,10 +490,9 @@ export const App = () => {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     padding: 20,
-    justifyContent: 'center',
     alignItems: 'flex-start',
+    paddingBottom: 40,
   },
   inlineContainer: {
     flexDirection: 'row',
@@ -548,6 +611,20 @@ const styles = StyleSheet.create({
     borderRadius: 5,
     width: '80%',
     marginVertical: 10,
+  },
+  webViewContainer: {
+    flex: 1,
+  },
+  webViewHeader: {
+    paddingHorizontal: 20,
+    paddingTop: 10,
+    paddingBottom: 4,
+  },
+  webViewCloseButton: {
+    alignSelf: 'flex-start',
+  },
+  webView: {
+    flex: 1,
   },
 });
 

--- a/examples/expo/src/lib/bitdrift.ts
+++ b/examples/expo/src/lib/bitdrift.ts
@@ -8,6 +8,7 @@ import {
   getSessionID,
   getSessionURL,
   getDeviceID,
+  getSdkStatus,
 } from '@bitdrift/react-native';
 
 const BITDRIFT_API_KEY = process.env.EXPO_PUBLIC_BITDRIFT_API_KEY;
@@ -16,6 +17,20 @@ if (BITDRIFT_API_KEY) {
   init(BITDRIFT_API_KEY, SessionStrategy.Fixed, {
     url: process.env.EXPO_PUBLIC_BITDRIFT_API_URL ?? 'https://api.bitdrift.io',
     enableNetworkInstrumentation: true,
+    startResult: (result) => {
+      console.log('Start result:', result);
+      console.log('SDK status after start result:', getSdkStatus());
+    },
+    UNSTABLE_webView: {
+      capturePageViews: true,
+      captureNetworkRequests: true,
+      captureNavigationEvents: true,
+      captureWebVitals: true,
+      captureLongTasks: true,
+      captureConsoleLogs: true,
+      captureUserInteractions: true,
+      captureErrors: true,
+    },
     
     // enableNativeFatalIssues Should be enabled by default
     crashReporting: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "metro": "^0.80.12",
         "metro-config": "^0.80.12",
         "metro-resolver": "^0.80.12",
-        "react": "18.3.1"
+        "react": "18.3.1",
+        "react-native": "0.76.9"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -88,7 +89,7 @@
         "react-native-svg": "15.11.1",
         "react-native-svg-transformer": "1.5.0",
         "react-native-web": "^0.19.13",
-        "react-native-webview": "~13.13.1",
+        "react-native-webview": "^13.16.1",
         "react-test-renderer": "^18.2.0",
         "rollup": "^4.14.0",
         "ts-jest": "^29.2.5",
@@ -20440,7 +20441,7 @@
       "version": "0.0.0-experimental-592953e-20240517",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-0.0.0-experimental-592953e-20240517.tgz",
       "integrity": "sha512-OjG1SVaeQZaJrqkMFJatg8W/MTow8Ak5rx2SI0ETQBO1XvOk/XZGMbltNCPdFJLKghBYoBjC+Y3Ap/Xr7B01mA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "7.2.0",
@@ -20456,7 +20457,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.0.tgz",
       "integrity": "sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.2.0",
@@ -20470,7 +20471,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
       "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -20485,7 +20486,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
       "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*",
@@ -20496,7 +20497,7 @@
       "version": "13.0.12",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
       "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -20506,7 +20507,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -20516,7 +20517,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20532,7 +20533,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20549,14 +20550,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/babel-plugin-react-compiler/node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -20569,7 +20570,7 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
       "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^24.9.0",
@@ -20585,7 +20586,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -20598,7 +20599,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -20608,14 +20609,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/babel-plugin-react-compiler/node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -32181,7 +32182,7 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -37221,9 +37222,9 @@
       "license": "MIT"
     },
     "node_modules/react-native-webview": {
-      "version": "13.13.5",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.13.5.tgz",
-      "integrity": "sha512-MfC2B+woL4Hlj2WCzcb1USySKk+SteXnUKmKktOk/H/AQy5+LuVdkPKm8SknJ0/RxaxhZ48WBoTRGaqgR137hw==",
+      "version": "13.16.1",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.1.tgz",
+      "integrity": "sha512-If0eHhoEdOYDcHsX+xBFwHMbWBGK1BvGDQDQdVkwtSIXiq1uiqjkpWVP2uQ1as94J0CzvFE9PUNDuhiX0Z6ubw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -42782,7 +42783,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -44865,7 +44866,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -44875,7 +44876,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-2.1.0.tgz",
       "integrity": "sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test": "nx affected --target=test --parallel",
     "lint": "nx affected --target=lint --parallel",
     "lint:all": "nx run-many --target=lint --parallel",
-    "fmt": "cargo +nightly fmt --manifest-path packages/core/Cargo.toml --all"
+    "fmt": "cargo +nightly fmt --manifest-path packages/core/Cargo.toml --all",
+    "android": "expo run:android",
+    "ios": "expo run:ios"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
@@ -77,15 +79,15 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-native": "~0.77.1",
-    "react-native-reanimated": "~3.16.7",
-    "react-native-gesture-handler": "~2.22.0",
-    "react-native-screens": "~4.8.0",
-    "react-native-safe-area-context": "~5.1.0",
-    "react-native-webview": "~13.13.1",
     "react-native-builder-bob": "^0.35.2",
+    "react-native-gesture-handler": "~2.22.0",
+    "react-native-reanimated": "~3.16.7",
+    "react-native-safe-area-context": "~5.1.0",
+    "react-native-screens": "~4.8.0",
     "react-native-svg": "15.11.1",
     "react-native-svg-transformer": "1.5.0",
     "react-native-web": "^0.19.13",
+    "react-native-webview": "^13.16.1",
     "react-test-renderer": "^18.2.0",
     "rollup": "^4.14.0",
     "ts-jest": "^29.2.5",
@@ -103,7 +105,8 @@
     "metro": "^0.80.12",
     "metro-config": "^0.80.12",
     "metro-resolver": "^0.80.12",
-    "react": "18.3.1"
+    "react": "18.3.1",
+    "react-native": "0.76.9"
   },
   "overrides": {
     "got": "^11.8.6"

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -20,6 +20,9 @@ Capture library and log messages at different log levels. Note that this initial
 import { init, trace, debug, info, warn, error, SessionStrategy } from '@bitdrift/react-native';
 
 init('<api key>', SessionStrategy.Activity, {
+  startResult: (result) => {
+    console.log('Capture start result', result);
+  },
   crashReporting: {
     enableNativeFatalIssues: true, // Enable native crash reporting (crashes, ANRs, etc.)
     UNSTABLE_enableJsErrors: true, // Enable JavaScript error reporting (fatal and non-fatal)
@@ -44,6 +47,14 @@ For all Expo usages, make sure to add `@bitdrift/react-native` to the `plugins` 
   }
 }
 ```
+
+Android-only WebView instrumentation note:
+
+- `UNSTABLE_webViewInstrumentation` currently only affects Android app builds.
+- In this package, automatic setup is only provided through the Expo config plugin / generated Android Gradle setup.
+- Non-Expo Android apps can still enable the same instrumentation manually by applying the Gradle plugin and configuring the `bitdrift` instrumentation block.
+- It does not affect iOS builds.
+- It does not automatically configure non-Expo / vanilla React Native Android projects.
 
 #### Expo Go
 
@@ -138,6 +149,63 @@ type PreviousRunInfo = {
 - Android: available on API 30+ (Android 11+); returns `null` on older versions.
 - iOS simulator: returns `null` by design; use a physical device to validate.
 - `terminationReason` is currently populated on Android. iOS currently provides `hasFatallyTerminated`.
+
+### SDK Status
+
+Use `getSdkStatus()` to inspect the SDK's current initialization state and recent backend activity.
+
+```ts
+import { getSdkStatus, init, SessionStrategy, type SdkStatus } from '@bitdrift/react-native';
+
+init('<api key>', SessionStrategy.Activity);
+
+const sdkStatus: SdkStatus = getSdkStatus();
+console.log(sdkStatus.initializationState);
+```
+
+`SdkStatus` shape:
+
+```ts
+type SdkStatus = {
+  initializationState: 'notStarted' | 'loaded' | 'running' | 'disabled';
+  lastHandshakeTimeMs?: number;
+  lastConfigDeliveryTimeMs?: number;
+};
+```
+
+- This API is synchronous.
+- It can be called before or after `init(...)`.
+- When Capture has not started yet, `initializationState` is `notStarted`.
+
+### Start Result Callback
+
+Use `startResult` to observe whether native SDK startup succeeded.
+
+```ts
+import { init, SessionStrategy } from '@bitdrift/react-native';
+
+init('<api key>', SessionStrategy.Activity, {
+  startResult: (result) => {
+    if (result.success) {
+      console.log('Capture started successfully');
+    } else {
+      console.log('Capture failed to start', result.error);
+    }
+  },
+});
+```
+
+`StartResult` shape:
+
+```ts
+type StartResult = {
+  success: boolean;
+  error?: string;
+};
+```
+
+- The callback is invoked at most once per `init(...)` call.
+- This callback is experimental and may change.
 
 ```js
 import { trace, debug, info, warn, error } from '@bitdrift/react-native';
@@ -259,6 +327,53 @@ When using Expo to generate the project, this can be achieved by setting the `ne
 ```
 
 When using the Expo plugin with `networkInstrumentation: true`, the Android Gradle plugin and `bitdrift { instrumentation { ... } }` block are generated automatically.
+
+### WebView Integration
+
+`UNSTABLE_webViewInstrumentation` is currently Android-only and is intended for Android app builds.
+
+Runtime capture is enabled separately with `UNSTABLE_webView` in `init(...)`:
+
+```ts
+import { init, SessionStrategy } from '@bitdrift/react-native';
+
+init('<api key>', SessionStrategy.Activity, {
+  UNSTABLE_webView: {
+    capturePageViews: true,
+    captureNetworkRequests: true,
+    captureNavigationEvents: true,
+    captureWebVitals: true,
+    captureLongTasks: true,
+    captureConsoleLogs: true,
+    captureUserInteractions: true,
+    captureErrors: true,
+  },
+});
+```
+
+For Expo-generated Android apps, enable build-time WebView bytecode instrumentation with:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "@bitdrift/react-native",
+        {
+          "UNSTABLE_webViewInstrumentation": true
+        }
+      ]
+    ]
+  }
+}
+```
+
+Notes:
+
+- `UNSTABLE_webViewInstrumentation` currently only affects Android app builds.
+- It is not used by iOS.
+- It is not automatically applied to vanilla React Native Android builds outside the Expo config plugin flow.
+- For non-Expo Android apps, apply the Gradle plugin and `bitdrift { instrumentation { automaticWebViewInstrumentation = true } }` manually.
 
 The Android plugin mode can be configured with `okHttpInstrumentationType`:
 

--- a/packages/react-native/android/src/main/java/com/bdreactnative/BdReactNativeModule.kt
+++ b/packages/react-native/android/src/main/java/com/bdreactnative/BdReactNativeModule.kt
@@ -15,6 +15,9 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import io.bitdrift.capture.Capture
+import io.bitdrift.capture.CaptureResult
+import io.bitdrift.capture.InitializationState
+import io.bitdrift.capture.SdkStatus
 import io.bitdrift.capture.providers.session.SessionStrategy
 import com.facebook.react.bridge.Promise
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -24,6 +27,7 @@ import io.bitdrift.capture.Configuration
 import io.bitdrift.capture.experimental.ExperimentalBitdriftApi
 import io.bitdrift.capture.reports.IssueCallbackConfiguration
 import io.bitdrift.capture.reports.IssueReportCallback
+import io.bitdrift.capture.webview.WebViewConfiguration
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -46,9 +50,11 @@ class BdReactNativeModule internal constructor(context: ReactApplicationContext)
   override fun init(key: String, sessionStrategy: String, options: ReadableMap?) {
     val apiUrl = options?.getString("url") ?: "https://api.bitdrift.io"
     val crashReportingOptions = options.getMapOrNull("crashReporting")
+    val webViewOptions = options.getMapOrNull("webView")
     val enableNativeFatalIssues = crashReportingOptions.getBooleanOrDefault("enableNativeFatalIssues", true)
     val enableJsErrors = crashReportingOptions.getBooleanOrDefault("UNSTABLE_enableJsErrors", false)
     val enableIssueCallbackBridge = crashReportingOptions.getBooleanOrDefault("enableIssueCallbackBridge", false)
+    val enableStartResultBridge = options.getBooleanOrDefault("enableStartResultBridge", false)
 
     ReportDirectory.setupWatcherDirectory(reactApplicationContext, enableJsErrors)
 
@@ -61,10 +67,22 @@ class BdReactNativeModule internal constructor(context: ReactApplicationContext)
 
     val configuration = Configuration(
       enableFatalIssueReporting = enableNativeFatalIssues,
+      webViewConfiguration = buildWebViewConfiguration(webViewOptions),
       issueCallbackConfiguration = buildIssueCallbackConfiguration(enableIssueCallbackBridge),
     )
 
-    Capture.Logger.start(apiKey = key, apiUrl = apiUrl.toHttpUrl(), sessionStrategy = strategy, configuration = configuration)
+    Capture.Logger.start(
+      apiKey = key,
+      apiUrl = apiUrl.toHttpUrl(),
+      sessionStrategy = strategy,
+      configuration = configuration,
+      context = reactApplicationContext,
+      startResult = if (enableStartResultBridge) {
+        { result -> emitStartResult(result) }
+      } else {
+        null
+      },
+    )
   }
 
   private fun buildCallbackExecutor(): ExecutorService {
@@ -85,6 +103,24 @@ class BdReactNativeModule internal constructor(context: ReactApplicationContext)
     } else {
       null
     }
+  }
+
+  @OptIn(ExperimentalBitdriftApi::class)
+  private fun buildWebViewConfiguration(webViewOptions: ReadableMap?): WebViewConfiguration? {
+    if (webViewOptions == null) {
+      return null
+    }
+
+    return WebViewConfiguration(
+      capturePageViews = webViewOptions.getBooleanOrDefault("capturePageViews", false),
+      captureNetworkRequests = webViewOptions.getBooleanOrDefault("captureNetworkRequests", false),
+      captureNavigationEvents = webViewOptions.getBooleanOrDefault("captureNavigationEvents", false),
+      captureWebVitals = webViewOptions.getBooleanOrDefault("captureWebVitals", false),
+      captureLongTasks = webViewOptions.getBooleanOrDefault("captureLongTasks", false),
+      captureConsoleLogs = webViewOptions.getBooleanOrDefault("captureConsoleLogs", false),
+      captureUserInteractions = webViewOptions.getBooleanOrDefault("captureUserInteractions", false),
+      captureErrors = webViewOptions.getBooleanOrDefault("captureErrors", false),
+    )
   }
   
   private fun emitIssueReport(report: io.bitdrift.capture.reports.Report) {
@@ -109,6 +145,22 @@ class BdReactNativeModule internal constructor(context: ReactApplicationContext)
       .emit(ISSUE_REPORT_EVENT, payload)
   }
 
+  private fun emitStartResult(result: CaptureResult<io.bitdrift.capture.ILogger>) {
+    if (!reactApplicationContext.hasActiveCatalystInstance()) {
+      return
+    }
+
+    reactApplicationContext.runOnUiQueueThread {
+      if (!reactApplicationContext.hasActiveCatalystInstance()) {
+        return@runOnUiQueueThread
+      }
+
+      reactApplicationContext
+        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+        .emit(START_RESULT_EVENT, toWritableStartResult(result))
+    }
+  }
+
   private fun toWritableIssueReport(report: io.bitdrift.capture.reports.Report): WritableMap {
     val payload = Arguments.createMap()
     payload.putString("reportType", report.reportType)
@@ -121,6 +173,21 @@ class BdReactNativeModule internal constructor(context: ReactApplicationContext)
       fieldsMap.putString(key, value)
     }
     payload.putMap("fields", fieldsMap)
+
+    return payload
+  }
+
+  private fun toWritableStartResult(result: CaptureResult<io.bitdrift.capture.ILogger>): WritableMap {
+    val payload = Arguments.createMap()
+    when (result) {
+      is CaptureResult.Success -> {
+        payload.putBoolean("success", true)
+      }
+      is CaptureResult.Failure -> {
+        payload.putBoolean("success", false)
+        payload.putString("error", result.error.message)
+      }
+    }
 
     return payload
   }
@@ -153,6 +220,11 @@ class BdReactNativeModule internal constructor(context: ReactApplicationContext)
     } else {
       promise.reject("session_url_undefined", "Session URL is undefined")
     }
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  override fun getSdkStatus(): WritableMap {
+    return toWritableSdkStatus(Capture.Logger.getSdkStatus())
   }
 
   @OptIn(ExperimentalBitdriftApi::class)
@@ -244,7 +316,24 @@ class BdReactNativeModule internal constructor(context: ReactApplicationContext)
     const val NAME = "BdReactNative"
     // Must match src/index.tsx ISSUE_REPORT_EVENT and iOS equivalents.
     private const val ISSUE_REPORT_EVENT = "BdReactNative.onBeforeReportSend"
+    private const val START_RESULT_EVENT = "BdReactNative.onStartResult"
     private const val ISSUE_CALLBACK_THREAD_NAME = "io.bitdrift.capture.reactnative.issue-callback"
+
+    private fun toWritableSdkStatus(status: SdkStatus): WritableMap {
+      val map = Arguments.createMap()
+      map.putString("initializationState", status.initializationState.toJsValue())
+      status.lastHandshakeTimeMs?.let { map.putDouble("lastHandshakeTimeMs", it.toDouble()) }
+      status.lastConfigDeliveryTimeMs?.let { map.putDouble("lastConfigDeliveryTimeMs", it.toDouble()) }
+      return map
+    }
+
+    private fun InitializationState.toJsValue(): String =
+      when (this) {
+        InitializationState.NOT_STARTED -> "notStarted"
+        InitializationState.LOADED -> "loaded"
+        InitializationState.RUNNING -> "running"
+        InitializationState.DISABLED -> "disabled"
+      }
 
     private fun ReadableMap?.getMapOrNull(key: String): ReadableMap? =
       this

--- a/packages/react-native/android/src/oldarch/BdReactNativeSpec.kt
+++ b/packages/react-native/android/src/oldarch/BdReactNativeSpec.kt
@@ -24,6 +24,8 @@ abstract class BdReactNativeSpec internal constructor(context: ReactApplicationC
 
   abstract fun getSessionURL(promise: Promise)
 
+  abstract fun getSdkStatus(): WritableMap
+
   abstract fun getPreviousRunInfo(): WritableMap?
 
   abstract fun log(level: Double, message: String, jsFields: ReadableMap?)

--- a/packages/react-native/ios/BdReactNative.mm
+++ b/packages/react-native/ios/BdReactNative.mm
@@ -8,10 +8,12 @@ RCT_EXPORT_MODULE()
 // Must match src/index.tsx ISSUE_REPORT_EVENT and Android equivalent.
 static NSString *const kIssueReportEventName = @"BdReactNative.onBeforeReportSend";
 static NSNotificationName const kIssueReportNotificationName = @"BdReactNative.onBeforeReportSend";
+static NSString *const kStartResultEventName = @"BdReactNative.onStartResult";
+static NSNotificationName const kStartResultNotificationName = @"BdReactNative.onStartResult";
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[kIssueReportEventName];
+  return @[kIssueReportEventName, kStartResultEventName];
 }
 
 - (void)startObserving
@@ -19,6 +21,10 @@ static NSNotificationName const kIssueReportNotificationName = @"BdReactNative.o
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(handleIssueReportNotification:)
                                                name:kIssueReportNotificationName
+                                              object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(handleStartResultNotification:)
+                                               name:kStartResultNotificationName
                                              object:nil];
 }
 
@@ -26,6 +32,9 @@ static NSNotificationName const kIssueReportNotificationName = @"BdReactNative.o
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self
                                                   name:kIssueReportNotificationName
+                                                 object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:kStartResultNotificationName
                                                 object:nil];
 }
 
@@ -34,6 +43,14 @@ static NSNotificationName const kIssueReportNotificationName = @"BdReactNative.o
   NSDictionary *payload = notification.userInfo ?: @{};
   dispatch_async(dispatch_get_main_queue(), ^{
     [self sendEventWithName:kIssueReportEventName body:payload];
+  });
+}
+
+- (void)handleStartResultNotification:(NSNotification *)notification
+{
+  NSDictionary *payload = notification.userInfo ?: @{};
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self sendEventWithName:kStartResultEventName body:payload];
   });
 }
 
@@ -69,6 +86,10 @@ RCT_EXPORT_METHOD(getSessionURL:(RCTPromiseResolveBlock)resolve reject:(RCTPromi
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getPreviousRunInfo) {
     return [CAPRNLogger getPreviousRunInfo];
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getSdkStatus) {
+    return [CAPRNLogger getSdkStatus];
 }
 
 RCT_EXPORT_METHOD(logScreenView:(NSString *)screenName)
@@ -118,6 +139,8 @@ RCT_EXPORT_METHOD(init:(NSString*)apiKey
   BOOL enableJsErrors = [crashReportingOptions[@"UNSTABLE_enableJsErrors"] boolValue];
   NSNumber* enableIssueCallbackBridgeValue = crashReportingOptions[@"enableIssueCallbackBridge"];
   BOOL enableIssueCallbackBridge = enableIssueCallbackBridgeValue != nil ? [enableIssueCallbackBridgeValue boolValue] : NO;
+  NSNumber* enableStartResultBridgeValue = options[@"enableStartResultBridge"];
+  BOOL enableStartResultBridge = enableStartResultBridgeValue != nil ? [enableStartResultBridgeValue boolValue] : NO;
 
   [CAPRNLogger
     startWithKey:apiKey
@@ -127,6 +150,7 @@ RCT_EXPORT_METHOD(init:(NSString*)apiKey
     enableNativeFatalIssues:enableNativeFatalIssues
     enableJsErrors:enableJsErrors
     enableIssueCallbackBridge:enableIssueCallbackBridge
+    enableStartResultBridge:enableStartResultBridge
   ];
 }
 
@@ -141,6 +165,7 @@ RCT_EXPORT_METHOD(init:(NSString*)apiKey
   BOOL enableNativeFatalIssues = true;
   BOOL enableJsErrors = false;
   BOOL enableIssueCallbackBridge = false;
+  BOOL enableStartResultBridge = options.enableStartResultBridge().has_value() ? options.enableStartResultBridge().value() : false;
   if (options.crashReporting().has_value()) {
     auto crashReporting = options.crashReporting().value();
     enableNativeFatalIssues = crashReporting.enableNativeFatalIssues().has_value() ? crashReporting.enableNativeFatalIssues().value() : true;
@@ -156,6 +181,7 @@ RCT_EXPORT_METHOD(init:(NSString*)apiKey
     enableNativeFatalIssues:enableNativeFatalIssues
     enableJsErrors:enableJsErrors
     enableIssueCallbackBridge:enableIssueCallbackBridge
+    enableStartResultBridge:enableStartResultBridge
   ];
 }
 

--- a/packages/react-native/ios/Logger.swift
+++ b/packages/react-native/ios/Logger.swift
@@ -10,6 +10,7 @@ import Foundation
 
 // Must match src/index.tsx ISSUE_REPORT_EVENT and Android/iOS bridge constants.
 let CAPRNIssueReportDidEmitNotification = Notification.Name("BdReactNative.onBeforeReportSend")
+let CAPRNStartResultDidEmitNotification = Notification.Name("BdReactNative.onStartResult")
 
 @objc public class CAPRNLogger: NSObject {
     
@@ -24,7 +25,8 @@ let CAPRNIssueReportDidEmitNotification = Notification.Name("BdReactNative.onBef
         enableNetworkInstrumentation: Bool,
         enableNativeFatalIssues: Bool,
         enableJsErrors: Bool,
-        enableIssueCallbackBridge: Bool
+        enableIssueCallbackBridge: Bool,
+        enableStartResultBridge: Bool
     ) {
         ReportDirectory.setupWatcherDirectory(enableJsErrors: enableJsErrors)
         
@@ -57,7 +59,30 @@ let CAPRNIssueReportDidEmitNotification = Notification.Name("BdReactNative.onBef
         let integrator = Capture.Logger.start(
             withAPIKey: key,
             sessionStrategy: strategy,
-            configuration: configuration
+            configuration: configuration,
+            startResult: { result in
+                guard enableStartResultBridge else {
+                    return
+                }
+
+                switch result {
+                case .success:
+                    NotificationCenter.default.post(
+                        name: CAPRNStartResultDidEmitNotification,
+                        object: nil,
+                        userInfo: ["success": true]
+                    )
+                case .failure(let error):
+                    NotificationCenter.default.post(
+                        name: CAPRNStartResultDidEmitNotification,
+                        object: nil,
+                        userInfo: [
+                            "success": false,
+                            "error": error.localizedDescription,
+                        ]
+                    )
+                }
+            }
         )
         
 
@@ -142,6 +167,24 @@ let CAPRNIssueReportDidEmitNotification = Notification.Name("BdReactNative.onBef
     }
 
     @objc
+    public static func getSdkStatus() -> [String: Any] {
+        let status = Capture.Logger.getSdkStatus()
+        var payload: [String: Any] = [
+            "initializationState": status.initializationState.jsValue,
+        ]
+
+        if let lastHandshakeTime = status.lastHandshakeTime {
+            payload["lastHandshakeTimeMs"] = Int64(lastHandshakeTime.timeIntervalSince1970 * 1000)
+        }
+
+        if let lastConfigDeliveryTime = status.lastConfigDeliveryTime {
+            payload["lastConfigDeliveryTimeMs"] = Int64(lastConfigDeliveryTime.timeIntervalSince1970 * 1000)
+        }
+
+        return payload
+    }
+
+    @objc
     public static func logScreenView(screenName: String) {
         Capture.Logger.logScreenView(screenName: screenName)
     }
@@ -213,5 +256,20 @@ private final class CAPRNIssueReportCallback: NSObject, IssueReportCallback {
                 "fields": report.fields,
             ]
         )
+    }
+}
+
+private extension InitializationState {
+    var jsValue: String {
+        switch self {
+        case .notStarted:
+            return "notStarted"
+        case .loaded:
+            return "loaded"
+        case .running:
+            return "running"
+        case .disabled:
+            return "disabled"
+        }
     }
 }

--- a/packages/react-native/src/NativeBdReactNative.ts
+++ b/packages/react-native/src/NativeBdReactNative.ts
@@ -22,9 +22,34 @@ export type CrashReportingOptions = {
   enableIssueCallbackBridge?: boolean;
 };
 
+export type InitializationState =
+  | 'notStarted'
+  | 'loaded'
+  | 'running'
+  | 'disabled';
+
+export type SdkStatus = {
+  initializationState: InitializationState;
+  lastHandshakeTimeMs?: number;
+  lastConfigDeliveryTimeMs?: number;
+};
+
+export type WebViewOptions = {
+  capturePageViews?: boolean;
+  captureNetworkRequests?: boolean;
+  captureNavigationEvents?: boolean;
+  captureWebVitals?: boolean;
+  captureLongTasks?: boolean;
+  captureConsoleLogs?: boolean;
+  captureUserInteractions?: boolean;
+  captureErrors?: boolean;
+};
+
 export type InitOptions = {
   url?: string;
   enableNetworkInstrumentation?: boolean;
+  enableStartResultBridge?: boolean;
+  webView?: WebViewOptions;
   crashReporting?: CrashReportingOptions;
 };
 
@@ -51,6 +76,8 @@ export interface Spec extends TurboModule {
   getSessionID(): Promise<string>;
 
   getSessionURL(): Promise<string>;
+
+  getSdkStatus(): SdkStatus;
 
   getPreviousRunInfo(): PreviousRunInfo;
 

--- a/packages/react-native/src/__tests__/index.test.tsx
+++ b/packages/react-native/src/__tests__/index.test.tsx
@@ -11,6 +11,7 @@ type TestSetup = {
   sdk: typeof import('../index');
   nativeModule: {
     init: jest.Mock;
+    getSdkStatus: jest.Mock;
   };
   nativeEventEmitterCtor: jest.Mock;
   nativeAddListener: jest.Mock;
@@ -36,6 +37,7 @@ function loadSdk(platform: PlatformName): TestSetup {
     getDeviceID: jest.fn(),
     getSessionID: jest.fn(),
     getSessionURL: jest.fn(),
+    getSdkStatus: jest.fn(),
     logScreenView: jest.fn(),
     logAppLaunchTTI: jest.fn(),
     reportJsError: jest.fn(),
@@ -219,6 +221,39 @@ describe('init crash reporting callback wiring', () => {
       expect.any(Function),
     );
   });
+
+  test('enables native start result bridge when callback is provided', () => {
+    const { sdk, nativeModule } = loadSdk('ios');
+
+    sdk.init('test-key', sdk.SessionStrategy.Fixed, {
+      startResult: jest.fn(),
+    });
+
+    expect(nativeModule.init).toHaveBeenCalledWith(
+      'test-key',
+      sdk.SessionStrategy.Fixed,
+      expect.objectContaining({
+        enableStartResultBridge: true,
+      }),
+    );
+  });
+
+  test('routes emitted start result payload to the registered callback once', () => {
+    const { sdk, nativeAddListener, removeListener } = loadSdk('ios');
+    const callback = jest.fn();
+
+    sdk.init('test-key', sdk.SessionStrategy.Fixed, {
+      startResult: callback,
+    });
+
+    const listener = nativeAddListener.mock.calls[0][1] as (result: unknown) => void;
+    const result = { success: false, error: 'failed' };
+
+    listener(result);
+
+    expect(callback).toHaveBeenCalledWith(result);
+    expect(removeListener).toHaveBeenCalled();
+  });
 });
 
 describe('generateDeviceCode URL handling', () => {
@@ -299,5 +334,22 @@ describe('generateDeviceCode URL handling', () => {
         method: 'POST',
       }),
     );
+  });
+});
+
+describe('getSdkStatus', () => {
+  test('returns native sdk status synchronously', () => {
+    const { sdk, nativeModule } = loadSdk('ios');
+    nativeModule.getSdkStatus.mockReturnValue({
+      initializationState: 'running',
+      lastHandshakeTimeMs: 123,
+      lastConfigDeliveryTimeMs: 456,
+    });
+
+    expect(sdk.getSdkStatus()).toEqual({
+      initializationState: 'running',
+      lastHandshakeTimeMs: 123,
+      lastConfigDeliveryTimeMs: 456,
+    });
   });
 });

--- a/packages/react-native/src/index.tsx
+++ b/packages/react-native/src/index.tsx
@@ -15,6 +15,7 @@ import {
 import {
   InitOptions as NativeInitOptions,
   CrashReportingOptions as NativeCrashReportingOptions,
+  SdkStatus as NativeSdkStatus,
   PreviousRunInfo as PreviousRunInfoModel,
   SessionStrategy,
 } from './NativeBdReactNative';
@@ -27,6 +28,7 @@ export { SessionStrategy } from './NativeBdReactNative';
 // - ios/BdReactNative.mm
 // - ios/Logger.swift
 const ISSUE_REPORT_EVENT = 'BdReactNative.onBeforeReportSend';
+const START_RESULT_EVENT = 'BdReactNative.onStartResult';
 const DEFAULT_API_URL = 'https://api.bitdrift.io';
 
 export type IssueReport = {
@@ -44,7 +46,16 @@ export type CrashReportingOptions = Omit<
   UNSTABLE_onBeforeReportSend?: (report: IssueReport) => void;
 };
 
+export type SdkStatus = NativeSdkStatus;
+
+export type StartResult = {
+  success: boolean;
+  error?: string;
+};
+
 export type InitOptions = Omit<NativeInitOptions, 'crashReporting'> & {
+  UNSTABLE_webView?: NativeInitOptions['webView'];
+  startResult?: (result: StartResult) => void;
   crashReporting?: CrashReportingOptions;
 };
 
@@ -53,6 +64,7 @@ type EventSubscription = { remove: () => void };
 let api_url = DEFAULT_API_URL;
 let api_key = '';
 let issueReportSubscription: EventSubscription | undefined;
+let startResultSubscription: EventSubscription | undefined;
 
 const LINKING_ERROR =
   `The package '@bitdrift/react-native' doesn't seem to be linked. Make sure: \n\n` +
@@ -92,6 +104,11 @@ function resetIssueReportSubscription() {
   issueReportSubscription = undefined;
 }
 
+function resetStartResultSubscription() {
+  startResultSubscription?.remove();
+  startResultSubscription = undefined;
+}
+
 function maybeRegisterIssueReportCallback(options?: InitOptions) {
   resetIssueReportSubscription();
 
@@ -108,6 +125,23 @@ function maybeRegisterIssueReportCallback(options?: InitOptions) {
   );
 }
 
+function maybeRegisterStartResultCallback(options?: InitOptions) {
+  resetStartResultSubscription();
+
+  const callback = options?.startResult;
+  if (!callback) {
+    return;
+  }
+
+  startResultSubscription = createIssueReportEmitter().addListener(
+    START_RESULT_EVENT,
+    (result: StartResult) => {
+      callback(result);
+      resetStartResultSubscription();
+    },
+  );
+}
+
 function toNativeInitOptions(apiUrl: string, options?: InitOptions): NativeInitOptions {
   const enableIssueCallbackBridge = Boolean(
     options?.crashReporting?.UNSTABLE_onBeforeReportSend,
@@ -116,6 +150,8 @@ function toNativeInitOptions(apiUrl: string, options?: InitOptions): NativeInitO
   return {
     ...options,
     url: apiUrl,
+    enableStartResultBridge: Boolean(options?.startResult),
+    webView: options?.UNSTABLE_webView,
     crashReporting: options?.crashReporting
       ? {
           enableNativeFatalIssues: options.crashReporting.enableNativeFatalIssues,
@@ -150,6 +186,7 @@ export function init(
   }
 
   maybeRegisterIssueReportCallback(options);
+  maybeRegisterStartResultCallback(options);
 
   const nativeOptions = toNativeInitOptions(api_url, options);
   return BdReactNative.init(key, sessionStrategy, nativeOptions);
@@ -226,6 +263,10 @@ export async function getSessionID(): Promise<string> {
 
 export async function getSessionURL(): Promise<string> {
   return NativeBdReactNative.getSessionURL();
+}
+
+export function getSdkStatus(): NativeSdkStatus {
+  return NativeBdReactNative.getSdkStatus();
 }
 
 export type { PreviousRunInfo } from './NativeBdReactNative';

--- a/packages/react-native/src/plugin/__fixtures__/withAndroid/adds-missing-okhttp-type.gradle
+++ b/packages/react-native/src/plugin/__fixtures__/withAndroid/adds-missing-okhttp-type.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'io.bitdrift.capture-plugin' version '__CAPTURE_PLUGIN_VERSION__'
+}
+
+plugins {
+    id 'com.android.application'
+}
+
+bitdrift {
+    instrumentation {
+        automaticOkHttpInstrumentation = true
+        okHttpInstrumentationType = OVERWRITE
+    }
+}
+
+
+repositories {
+    maven {
+        url 'https://dl.bitdrift.io/sdk/android-maven'
+        content {
+          includeGroup 'io.bitdrift'
+        }
+    }
+}

--- a/packages/react-native/src/plugin/__fixtures__/withAndroid/appends-okhttp-block.gradle
+++ b/packages/react-native/src/plugin/__fixtures__/withAndroid/appends-okhttp-block.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'io.bitdrift.capture-plugin' version '__CAPTURE_PLUGIN_VERSION__'
+}
+
+plugins {
+    id 'com.android.application'
+}
+
+
+bitdrift {
+    instrumentation {
+        automaticOkHttpInstrumentation = true
+        okHttpInstrumentationType = PROXY
+    }
+}
+
+
+repositories {
+    maven {
+        url 'https://dl.bitdrift.io/sdk/android-maven'
+        content {
+          includeGroup 'io.bitdrift'
+        }
+    }
+}

--- a/packages/react-native/src/plugin/__fixtures__/withAndroid/appends-webview-block.gradle
+++ b/packages/react-native/src/plugin/__fixtures__/withAndroid/appends-webview-block.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'io.bitdrift.capture-plugin' version '__CAPTURE_PLUGIN_VERSION__'
+}
+
+plugins {
+    id 'com.android.application'
+}
+
+
+bitdrift {
+    instrumentation {
+        automaticWebViewInstrumentation = true
+    }
+}
+
+
+repositories {
+    maven {
+        url 'https://dl.bitdrift.io/sdk/android-maven'
+        content {
+          includeGroup 'io.bitdrift'
+        }
+    }
+}

--- a/packages/react-native/src/plugin/__fixtures__/withAndroid/injects-okhttp-into-existing-block.gradle
+++ b/packages/react-native/src/plugin/__fixtures__/withAndroid/injects-okhttp-into-existing-block.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'io.bitdrift.capture-plugin' version '__CAPTURE_PLUGIN_VERSION__'
+}
+
+plugins {
+    id 'com.android.application'
+}
+
+bitdrift {
+    instrumentation {
+        automaticOkHttpInstrumentation = true
+        okHttpInstrumentationType = OVERWRITE
+        automaticWebViewInstrumentation = true
+    }
+}
+
+
+repositories {
+    maven {
+        url 'https://dl.bitdrift.io/sdk/android-maven'
+        content {
+          includeGroup 'io.bitdrift'
+        }
+    }
+}

--- a/packages/react-native/src/plugin/__fixtures__/withAndroid/injects-webview-into-existing-block.gradle
+++ b/packages/react-native/src/plugin/__fixtures__/withAndroid/injects-webview-into-existing-block.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'io.bitdrift.capture-plugin' version '__CAPTURE_PLUGIN_VERSION__'
+}
+
+plugins {
+    id 'com.android.application'
+}
+
+bitdrift {
+    instrumentation {
+        automaticWebViewInstrumentation = true
+        automaticOkHttpInstrumentation = true
+        okHttpInstrumentationType = PROXY
+    }
+}
+
+
+repositories {
+    maven {
+        url 'https://dl.bitdrift.io/sdk/android-maven'
+        content {
+          includeGroup 'io.bitdrift'
+        }
+    }
+}

--- a/packages/react-native/src/plugin/config.ts
+++ b/packages/react-native/src/plugin/config.ts
@@ -9,4 +9,5 @@ export default interface PluginProps {
   networkInstrumentation?: boolean;
   // Android-only. Only used when networkInstrumentation is true.
   okHttpInstrumentationType?: 'PROXY' | 'OVERWRITE';
+  UNSTABLE_webViewInstrumentation?: boolean;
 }

--- a/packages/react-native/src/plugin/withAndroid.test.ts
+++ b/packages/react-native/src/plugin/withAndroid.test.ts
@@ -1,0 +1,141 @@
+// capture-es - bitdrift's ES SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+import fs from 'node:fs';
+import path from 'node:path';
+import withAndroid from './withAndroid';
+
+const { captureSdkVersion } = require('../../package.json') as {
+  captureSdkVersion: string;
+};
+
+jest.mock('@expo/config-plugins', () => ({
+  withPlugins: jest.fn((config, plugins) =>
+    plugins.reduce((nextConfig: unknown, [plugin, props]: [(config: unknown, props?: unknown) => unknown, unknown]) => {
+      return plugin(nextConfig, props);
+    }, config),
+  ),
+  withAppBuildGradle: jest.fn((config, action) => action(config)),
+  withSettingsGradle: jest.fn((config, action) => action(config)),
+}));
+
+type ConfigWithContents = {
+  modResults: {
+    contents: string;
+  };
+};
+
+function applyAppBuildGradlePlugin(
+  contents: string,
+  props?: {
+    networkInstrumentation?: boolean;
+    okHttpInstrumentationType?: 'PROXY' | 'OVERWRITE';
+    UNSTABLE_webViewInstrumentation?: boolean;
+  },
+): string {
+  const config = {
+    modResults: {
+      contents,
+    },
+  } as ConfigWithContents;
+
+  return (withAndroid(config, props) as ConfigWithContents).modResults.contents;
+}
+
+function readFixture(name: string): string {
+  return fs
+    .readFileSync(path.join(__dirname, '__fixtures__', 'withAndroid', name), 'utf8')
+    .replaceAll('__CAPTURE_PLUGIN_VERSION__', captureSdkVersion);
+}
+
+describe('withAndroid', () => {
+  test('appends a new bitdrift block for OkHttp instrumentation', () => {
+    const contents = `plugins {
+    id 'com.android.application'
+}
+`;
+
+    expect(
+      applyAppBuildGradlePlugin(contents, {
+        networkInstrumentation: true,
+      }),
+    ).toBe(readFixture('appends-okhttp-block.gradle'));
+  });
+
+  test('injects OkHttp instrumentation into an existing bitdrift block', () => {
+    const contents = `plugins {
+    id 'com.android.application'
+}
+
+bitdrift {
+    instrumentation {
+        automaticWebViewInstrumentation = true
+    }
+}
+`;
+
+    expect(
+      applyAppBuildGradlePlugin(contents, {
+        networkInstrumentation: true,
+        okHttpInstrumentationType: 'OVERWRITE',
+      }),
+    ).toBe(readFixture('injects-okhttp-into-existing-block.gradle'));
+  });
+
+  test('adds only missing okHttpInstrumentationType when automatic flag already exists', () => {
+    const contents = `plugins {
+    id 'com.android.application'
+}
+
+bitdrift {
+    instrumentation {
+        automaticOkHttpInstrumentation = true
+    }
+}
+`;
+
+    expect(
+      applyAppBuildGradlePlugin(contents, {
+        networkInstrumentation: true,
+        okHttpInstrumentationType: 'OVERWRITE',
+      }),
+    ).toBe(readFixture('adds-missing-okhttp-type.gradle'));
+  });
+
+  test('injects WebView instrumentation into an existing bitdrift block', () => {
+    const contents = `plugins {
+    id 'com.android.application'
+}
+
+bitdrift {
+    instrumentation {
+        automaticOkHttpInstrumentation = true
+        okHttpInstrumentationType = PROXY
+    }
+}
+`;
+
+    expect(
+      applyAppBuildGradlePlugin(contents, {
+        UNSTABLE_webViewInstrumentation: true,
+      }),
+    ).toBe(readFixture('injects-webview-into-existing-block.gradle'));
+  });
+
+  test('appends a new bitdrift block for WebView instrumentation', () => {
+    const contents = `plugins {
+    id 'com.android.application'
+}
+`;
+
+    expect(
+      applyAppBuildGradlePlugin(contents, {
+        UNSTABLE_webViewInstrumentation: true,
+      }),
+    ).toBe(readFixture('appends-webview-block.gradle'));
+  });
+});

--- a/packages/react-native/src/plugin/withAndroid.ts
+++ b/packages/react-native/src/plugin/withAndroid.ts
@@ -8,50 +8,86 @@
 import { withPlugins } from '@expo/config-plugins';
 import { withAppBuildGradle, withSettingsGradle } from '@expo/config-plugins';
 import type { ConfigPlugin } from '@expo/config-plugins';
-import PluginProps from './config';
+import type PluginProps from './config';
 
 const CAPTURE_PLUGIN_ID = "id 'io.bitdrift.capture-plugin'";
 const BITDRIFT_MAVEN_HOST = 'dl.bitdrift.io';
 
-const withBitdriftAppBuildGradle: ConfigPlugin<PluginProps | void> = (
-  config,
-  props,
-) => {
-  return withAppBuildGradle(config, (config) => {
-    const shouldEnableNetworkInstrumentation = props?.networkInstrumentation === true;
-    const okHttpInstrumentationType =
-      props?.okHttpInstrumentationType === 'OVERWRITE' ? 'OVERWRITE' : 'PROXY';
-
-    if (
-      shouldEnableNetworkInstrumentation &&
-      !config.modResults.contents.includes(CAPTURE_PLUGIN_ID)
-    ) {
-      config.modResults.contents =
-        `plugins {
-    id 'io.bitdrift.capture-plugin' version '0.23.5'
+function insertIntoInstrumentationBlock(contents: string, lines: string[]): string {
+  return contents.replace(
+    '    instrumentation {',
+    ['    instrumentation {', ...lines.map((line) => `        ${line}`)].join('\n'),
+  );
 }
 
-` + config.modResults.contents;
-    }
-
-    if (
-      shouldEnableNetworkInstrumentation &&
-      !config.modResults.contents.includes('automaticOkHttpInstrumentation')
-    ) {
-      config.modResults.contents += `
+function appendBitdriftInstrumentationBlock(contents: string, lines: string[]): string {
+  return `${contents}
 
 bitdrift {
     instrumentation {
-        automaticOkHttpInstrumentation = true
-        okHttpInstrumentationType = ${okHttpInstrumentationType}
+${lines.map((line) => `        ${line}`).join('\n')}
     }
 }
 `;
+}
+
+function ensureOkHttpInstrumentation(
+  contents: string,
+  okHttpInstrumentationType: 'PROXY' | 'OVERWRITE',
+): string {
+  if (!contents.includes('automaticOkHttpInstrumentation')) {
+    if (contents.includes('bitdrift {')) {
+      return insertIntoInstrumentationBlock(contents, [
+        'automaticOkHttpInstrumentation = true',
+        `okHttpInstrumentationType = ${okHttpInstrumentationType}`,
+      ]);
     }
 
-    if (!config.modResults.contents.includes(BITDRIFT_MAVEN_HOST)) {
-      // Define the bitdrift maven repository at the end. This is necessary to resolve the SDK dependency specified by the plugin.
-      config.modResults.contents += `
+    return appendBitdriftInstrumentationBlock(contents, [
+      'automaticOkHttpInstrumentation = true',
+      `okHttpInstrumentationType = ${okHttpInstrumentationType}`,
+    ]);
+  }
+
+  if (!contents.includes('okHttpInstrumentationType')) {
+    return contents.replace(
+      '        automaticOkHttpInstrumentation = true',
+      [
+        '        automaticOkHttpInstrumentation = true',
+        `        okHttpInstrumentationType = ${okHttpInstrumentationType}`,
+      ].join('\n'),
+    );
+  }
+
+  return contents;
+}
+
+function ensureWebViewInstrumentation(contents: string): string {
+  if (contents.includes('automaticWebViewInstrumentation')) {
+    return contents;
+  }
+
+  if (contents.includes('bitdrift {')) {
+    return insertIntoInstrumentationBlock(contents, [
+      'automaticWebViewInstrumentation = true',
+    ]);
+  }
+
+  return appendBitdriftInstrumentationBlock(contents, [
+    'automaticWebViewInstrumentation = true',
+  ]);
+}
+
+function prependCapturePlugin(contents: string): string {
+  return `plugins {
+    id 'io.bitdrift.capture-plugin' version '0.23.5'
+}
+
+${contents}`;
+}
+
+function appendBitdriftRepository(contents: string): string {
+  return `${contents}
 
 repositories {
     maven {
@@ -62,6 +98,45 @@ repositories {
     }
 }
 `;
+}
+
+const withBitdriftAppBuildGradle: ConfigPlugin<PluginProps | void> = (
+  config,
+  props,
+) => {
+  return withAppBuildGradle(config, (config) => {
+    const shouldEnableNetworkInstrumentation = props?.networkInstrumentation === true;
+    const shouldEnableWebViewInstrumentation =
+      props?.UNSTABLE_webViewInstrumentation === true;
+    const shouldEnablePluginInstrumentation =
+      shouldEnableNetworkInstrumentation || shouldEnableWebViewInstrumentation;
+    const okHttpInstrumentationType =
+      props?.okHttpInstrumentationType === 'OVERWRITE' ? 'OVERWRITE' : 'PROXY';
+
+    if (
+      shouldEnablePluginInstrumentation &&
+      !config.modResults.contents.includes(CAPTURE_PLUGIN_ID)
+    ) {
+      config.modResults.contents = prependCapturePlugin(config.modResults.contents);
+    }
+
+    if (shouldEnableNetworkInstrumentation) {
+      config.modResults.contents = ensureOkHttpInstrumentation(
+        config.modResults.contents,
+        okHttpInstrumentationType,
+      );
+    }
+
+    if (shouldEnableWebViewInstrumentation) {
+      config.modResults.contents = ensureWebViewInstrumentation(
+        config.modResults.contents,
+      );
+    }
+
+    if (!config.modResults.contents.includes(BITDRIFT_MAVEN_HOST)) {
+      config.modResults.contents = appendBitdriftRepository(
+        config.modResults.contents,
+      );
     }
 
     return config;


### PR DESCRIPTION
## Summary

Resolves BIT-8545

Depends on https://github.com/bitdriftlabs/capture-sdk/pull/1016

- Added option (`UNSTABLE_webView`) to enable webview instrumentation for Android apps
- Add missing public native API parity for `getSdkStatus()` and `startResult` initialization callbacks on iOS and Android.
- Add tests for withAndroid.ts for build.gradle generation expectations

## Verification
- Verified webview instrumentation via android app [with this session](https://timeline.bitdrift.dev/session/92922d37-150e-4729-9136-3d9904ac43ac?utm_source=sdk&utilization=0&expanded=-432555946658442633)
- Triggered the unit tests on ci from local branch (alternatively you can do `SKIP_PROTO_GEN=true npm run test`):
   
   | [Success](https://github.com/bitdriftlabs/capture-es/actions/runs/27410071805/job/81008856347) | [Failed - Artificially triggered](https://github.com/bitdriftlabs/capture-es/actions/runs/27410167965/job/81009182854) |
   | ---------| -------|
   |  <img width="974" height="572" alt="Screenshot 2026-06-12 at 12 33 43" src="https://github.com/user-attachments/assets/02ec6d5d-a758-411f-b9c0-86c2853f5a35" /> | <img width="852" height="579" alt="Screenshot 2026-06-12 at 12 33 08" src="https://github.com/user-attachments/assets/22808ba7-0101-4789-8ba1-6af1f409db2b" /> |

- Verified other public APIs work as expected on iOS/Android (see below)

    | Android | iOS |
    | --------| ------|
    | <img width="272" height="295" alt="Screenshot 2026-06-12 at 12 41 53" src="https://github.com/user-attachments/assets/27f0ecb1-8296-432a-b8d1-f24cff248bd5" /> | <img width="315" height="550" alt="Screenshot 2026-06-12 at 12 54 18" src="https://github.com/user-attachments/assets/fcefde4b-f264-48bb-97d0-b6b516fafa48" /> |


